### PR TITLE
Update COLING.json

### DIFF
--- a/ai/B/COLING.json
+++ b/ai/B/COLING.json
@@ -1,6 +1,6 @@
 {
   "name": "COLING",
-  "full_name": "IEEE International Conference on Multimedia and Expo",
+  "full_name": "International Conference on Computational Linguistics",
   "website": "",
   "dblp": "https://dblp.org/db/conf/coling/index.html",
   "yearly_data": [


### PR DESCRIPTION
Corrected the full official name of the COLING (International Conference on Computational Linguistics) conference. 